### PR TITLE
fix:デプロイにおけるプラットフォームの修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,10 @@ GEM
     nio4r (2.7.1)
     nokogiri (1.16.4-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.16.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.4-x86_64-linux)
+      racc (~> 1.4)
     pg (1.5.6)
     psych (5.1.2)
       stringio
@@ -214,6 +218,8 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-23
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap
@@ -236,4 +242,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.5.9
+   2.4.10


### PR DESCRIPTION
Renderへのデプロイのために下記内容を追加、修正した。

- プラットフォームに「x86_64-linux」を追加。